### PR TITLE
Relax bounds on lens

### DIFF
--- a/quickcheck-contractmodel/quickcheck-contractmodel.cabal
+++ b/quickcheck-contractmodel/quickcheck-contractmodel.cabal
@@ -81,7 +81,7 @@ library
       base >=4.7 && <5,
       bytestring ^>= 0.10.12,
       containers ^>= 0.6.5.1,
-      lens ^>= 5.2,
+      lens ^>= 5.0 || ^>= 5.1 || ^>= 5.2,
       mmorph ^>= 1.2,
       mtl ^>= 2.2.2,
       pretty ^>= 1.1.3.6,


### PR DESCRIPTION
Tested with

```
cabal build quickcheck-contractmodel --constraint="lens^>=5.0" --allow-older=quickcheck-contractmodel:lens
cabal build quickcheck-contractmodel --constraint="lens^>=5.1" --allow-older=quickcheck-contractmodel:lens
```