### PR TITLE
Revise cardano-api lower bound to 1.35.4

### DIFF
--- a/quickcheck-contractmodel/quickcheck-contractmodel.cabal
+++ b/quickcheck-contractmodel/quickcheck-contractmodel.cabal
@@ -92,7 +92,7 @@ library
     -- Plutus and Cardano dependencies
     build-depends:
       plutus-tx ^>= 1.0,
-      cardano-api ^>= 1.35,
+      cardano-api ^>= 1.35.4,
       cardano-ledger-core ^>= 0.1,
       cardano-ledger-alonzo ^>= 0.1,
       cardano-ledger-shelley ^>= 0.1,


### PR DESCRIPTION
The library does not in fact seem to build with 1.35.3.
