### PR TITLE
Add ability to make assertions of the blockchain in DL properties

### DIFF
--- a/quickcheck-contractmodel/quickcheck-contractmodel.cabal
+++ b/quickcheck-contractmodel/quickcheck-contractmodel.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               quickcheck-contractmodel
-version:            0.1.2.0
+version:            0.1.3.0
 
 -- A short (one-line) description of the package.
 -- synopsis:

--- a/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/DL.hs
+++ b/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/DL.hs
@@ -6,6 +6,8 @@ import Data.Typeable
 
 import Test.QuickCheck.ContractModel.Internal.Model
 import Test.QuickCheck.ContractModel.Internal.Spec
+import Test.QuickCheck.ContractModel.Internal.ChainIndex
+import Test.QuickCheck.ContractModel.Internal.Symbolics
 import Test.QuickCheck.DynamicLogic          qualified as DL
 import Test.QuickCheck.StateModel            qualified as StateModel
 import Test.QuickCheck
@@ -110,6 +112,9 @@ instance ContractModel state => ActionLike state (Action state) where
 
 instance (ContractModel state, Typeable a) => ActionLike state (StateModel.Action (ModelState state) a) where
   action cmd = void $ DL.action cmd
+
+observe :: ContractModel state => String -> ((SymToken -> AssetId) -> ChainState -> Bool) -> DL state ()
+observe o p = action $ Observation o p
 
 waitUntilDL :: forall state. ContractModel state => SlotNo -> DL state ()
 waitUntilDL = action . WaitUntil
@@ -261,6 +266,7 @@ forAllUniqueDL state dl prop = DL.forAllUniqueDL state dl (prop . fromStateModel
 instance ContractModel s => DL.DynLogicModel (ModelState s) where
     restricted (ContractAction _ act) = restricted act
     restricted WaitUntil{}            = False
+    restricted Observation{}          = True
 
 instance GetModelState (DL state) where
     type StateType (DL state) = state

--- a/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/ChainIndex.hs
+++ b/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/ChainIndex.hs
@@ -1,6 +1,8 @@
 module Test.QuickCheck.ContractModel.Internal.ChainIndex where
 
 import Control.Monad.State
+import Control.Monad.Reader
+import Control.Monad.Writer
 
 import Data.Ord
 import Data.List
@@ -39,6 +41,7 @@ instance Semigroup ChainIndex where
 
 class HasChainIndex m where
   getChainIndex :: m ChainIndex
+  getChainState :: m ChainState
 
 allMinAda :: ChainIndex
           -> ProtocolParameters
@@ -92,3 +95,12 @@ txBalanceChanges (TxInState tx ChainState{..} accepted)
 
 instance (Monad m, HasChainIndex m) => HasChainIndex (StateT s m) where
   getChainIndex = lift $ getChainIndex
+  getChainState = lift $ getChainState
+
+instance (Monad m, HasChainIndex m) => HasChainIndex (ReaderT r m) where
+  getChainIndex = lift $ getChainIndex
+  getChainState = lift $ getChainState
+
+instance (Monad m, Monoid w, HasChainIndex m) => HasChainIndex (WriterT w m) where
+  getChainIndex = lift $ getChainIndex
+  getChainState = lift $ getChainState


### PR DESCRIPTION
Unfortunately, this required a minor change to the API to work nicely. In particular, this means the downstream needs to add stuff to the `HasChainIndex` instance. Therefore we also bump the version. @berewt Do you think this makes sense, and if so how quickly do you think we can get this into CHaP?