### PR TITLE
Bring back GHC 8.10.7 support

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -2,5 +2,5 @@
 # https://www.github.com/input-output-hk/iogx#32-nixhaskellnix
 
 {
-  supportedCompilers = [ "ghc928" ];
+  supportedCompilers = [ "ghc928" "ghc8107" ];
 }

--- a/quickcheck-threatmodel/quickcheck-threatmodel.cabal
+++ b/quickcheck-threatmodel/quickcheck-threatmodel.cabal
@@ -71,10 +71,10 @@ library
     -- General dependencies
     build-depends:
       base >=4.7 && <5,
-      bytestring ^>= 0.11.4,
+      bytestring >=0.10.12 && <0.12,
       containers ^>= 0.6.5.1,
       pretty ^>= 1.1.3.6,
-      time ^>= 1.11.1,
+      time >= 1.9.3 && <1.12,
     -- QuickCheck dependencies
     build-depends:
       QuickCheck ^>= 2.14,


### PR DESCRIPTION
Apparently this is required by CHaP.