### PR TITLE
cardano-api: 8.38 -> 9.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2024-02-14T00:00:00Z
-  , cardano-haskell-packages 2024-02-14T00:00:00Z
+  , hackage.haskell.org 2024-07-29T00:00:00Z
+  , cardano-haskell-packages 2024-07-29T00:00:00Z
 
 packages:
   quickcheck-contractmodel

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1707817466,
-        "narHash": "sha256-RhYwVypc8e14QlBqjkF2O7/G7J8p95xUwN5QcLo/VG4=",
+        "lastModified": 1722231085,
+        "narHash": "sha256-IwLw5BCQNLIp9CJgtnGU5wrQ5dr1zZ5UhOFJTZPx3w8=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "621ebfa536d0618f302ece9fb30f6cb050c9406e",
+        "rev": "843c3f288a53dd3f4f773413fc50201e003e0096",
         "type": "github"
       },
       "original": {
@@ -955,11 +955,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1707870123,
-        "narHash": "sha256-pOvz6uuPYw3CiPgi63QhNYumoKeyzDh9JOkLDngGWsE=",
+        "lastModified": 1722212837,
+        "narHash": "sha256-i1AcE+U+bt49BsfZdpLJgaeTOTBhm8PGuT5hLhoRSjs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "75345eba5d4159e6f54cbdc38785d1e0d0e655e0",
+        "rev": "f0102663eaec4749711b061283cb9fb6bafdf8c6",
         "type": "github"
       },
       "original": {

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -8,8 +8,6 @@ let
       name = "quickcheck-contract-model";
       src = ../.;
       compiler-nix-name = lib.mkDefault "ghc962";
-      flake.variants.ghc928.compiler-nix-name = "ghc928";
-      flake.variants.ghc8107.compiler-nix-name = "ghc8107";
       shell.withHoogle = false;
       inputMap = {
         "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.iogx.inputs.CHaP;

--- a/quickcheck-contractmodel/quickcheck-contractmodel.cabal
+++ b/quickcheck-contractmodel/quickcheck-contractmodel.cabal
@@ -84,11 +84,11 @@ library
       barbies ^>= 2.0.4.0
     -- QuickCheck dependencies
     build-depends:
-      QuickCheck ^>= 2.14,
-      quickcheck-dynamic >= 3.2.0 && < 3.4,
+      QuickCheck >= 2.14 && < 2.16,
+      quickcheck-dynamic >= 3.2.0 && < 3.5,
       quickcheck-threatmodel
     -- Plutus and Cardano dependencies
     build-depends:
-      cardano-api                                     >= 8.38 && < 8.39,
-      cardano-ledger-core                             >= 1.2.0 && < 1.11,
-      cardano-ledger-shelley                          >= 1.2.0 && < 1.10,
+      cardano-api                                     >= 9.0 && < 9.2,
+      cardano-ledger-core                             >= 1.2.0 && < 1.14,
+      cardano-ledger-shelley                          >= 1.2.0 && < 1.13,

--- a/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal.hs
+++ b/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal.hs
@@ -24,8 +24,10 @@ import Data.Map qualified as Map
 import Data.Maybe
 import Text.PrettyPrint.HughesPJClass hiding ((<>))
 
-import Cardano.Api
-import Cardano.Api.Shelley
+import Cardano.Api hiding ((<+>))
+import Cardano.Api.Shelley hiding ((<+>))
+import Cardano.Ledger.Coin
+import Data.Void
 
 class (ContractModel state, IsRunnable m) => RunModel state m where
   -- | Perform an `Action` in some `state` in the `Monad` `m`.  This
@@ -50,7 +52,7 @@ class (ContractModel state, IsRunnable m) => RunModel state m where
   monitoring :: (ModelState state, ModelState state)
              -> Action state
              -> (forall t. HasSymbolicRep t => Symbolic t -> t)
-             -> SymIndex
+             -> Either Void SymIndex
              -> Property
              -> Property
   monitoring _ _ _ _ prop = prop
@@ -228,7 +230,7 @@ assertBalanceChangesMatch (BalanceChangeOptions observeScript computeFees protoP
 
   in counterexample msg $ property $ checkEqualUpToMinAda minAda predictedBalanceChanges actualBalanceChanges
   where
-    checkEqualUpToMinAda :: Lovelace
+    checkEqualUpToMinAda :: Coin
                          -> Map (AddressInEra Era) Value
                          -> Map (AddressInEra Era) Value
                          -> Bool

--- a/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/ChainIndex.hs
+++ b/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/ChainIndex.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Keys (WitVKey (..), hashKey, coerceKeyRole)
 
 import Test.QuickCheck.ContractModel.Internal.Common
 import Test.QuickCheck.ContractModel.Internal.Utils
+import Cardano.Api.Ledger (Coin)
 
 data ChainState = ChainState
   { slot :: SlotNo
@@ -44,7 +45,7 @@ class HasChainIndex m where
 
 allMinAda :: ChainIndex
           -> LedgerProtocolParameters Era
-          -> [Lovelace]
+          -> [Coin]
 allMinAda ci (LedgerProtocolParameters params) =
   [ l
   | TxInState{..} <- transactions ci

--- a/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/Model.hs
+++ b/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/Model.hs
@@ -289,8 +289,7 @@ instance ContractModel state => StateModel.StateModel (ModelState state) where
   nextState s (WaitUntil n) _          = runSpec (() <$ waitUntil n) (error "unreachable") s
   nextState s (Observation _ _) _      = s
 
-  -- TODO: probably wise to avoid binding tokens here
-  failureNextState s (ContractAction _ cmd) = runSpec (failureNextState cmd) StateModel.failureResult s
+  failureNextState s (ContractAction _ cmd) = runSpec (failureNextState cmd) (error "A result of a failing action has been erronesouly inspected") s
   failureNextState _ _ = error "The impossible happened in failureNextState"
 
   -- Note that the order of the preconditions in this case matter - we want to run

--- a/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/Symbolics.hs
+++ b/quickcheck-contractmodel/src/Test/QuickCheck/ContractModel/Internal/Symbolics.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 module Test.QuickCheck.ContractModel.Internal.Symbolics where
 
-import Cardano.Api hiding (txIns)
+import Cardano.Api hiding (txIns, Pretty, (<+>), Doc)
 import Control.Lens
 
 import Test.QuickCheck.StateModel

--- a/quickcheck-threatmodel/quickcheck-threatmodel.cabal
+++ b/quickcheck-threatmodel/quickcheck-threatmodel.cabal
@@ -77,20 +77,20 @@ library
       time >= 1.9.3 && <1.13,
     -- QuickCheck dependencies
     build-depends:
-      QuickCheck ^>= 2.14,
+      QuickCheck >= 2.14 && < 2.16
     -- Plutus and Cardano dependencies
     build-depends:
-      plutus-tx                                       >= 1.5.0 && < 1.22,
-      cardano-api                                     >= 8.38 && < 8.39,
+      plutus-tx                                       >= 1.5.0 && < 1.31,
+      cardano-api                                     >= 9.0   && < 9.2,
       cardano-strict-containers                       >= 0.1.2 && < 0.2,
-      cardano-slotting                                >= 0.1.1 && < 0.2,
+      cardano-slotting                                >= 0.1.1 && < 0.3,
       cardano-ledger-binary                           >= 1.1.1 && < 1.4,
-      cardano-ledger-allegra                          >= 1.1.1 && < 1.4,
-      cardano-ledger-core                             >= 1.2.0 && < 1.11,
-      cardano-ledger-shelley                          >= 1.2.0 && < 1.10,
-      cardano-ledger-alonzo                           >= 1.2.1 && < 1.7,
-      cardano-ledger-api                              >= 1.2.0 && < 1.9,
-      cardano-ledger-babbage                          >= 1.2.1 && < 1.7,
-      ouroboros-consensus                             >= 0.7.0 && < 0.16,
-      ouroboros-consensus-cardano                     >= 0.6.0 && < 0.14,
-      sop-extras                                      >= 0.1.0 && < 0.2,
+      cardano-ledger-allegra                          >= 1.1.1 && < 1.6,
+      cardano-ledger-core                             >= 1.2.0 && < 1.14,
+      cardano-ledger-shelley                          >= 1.2.0 && < 1.13,
+      cardano-ledger-alonzo                           >= 1.2.1 && < 1.11,
+      cardano-ledger-api                              >= 1.2.0 && < 1.10,
+      cardano-ledger-babbage                          >= 1.2.1 && < 1.9,
+      ouroboros-consensus                             >= 0.7.0 && < 0.21,
+      ouroboros-consensus-cardano                     >= 0.6.0 && < 0.19,
+      sop-extras                                      >= 0.1.0 && < 0.3,

--- a/quickcheck-threatmodel/src/Test/QuickCheck/ThreatModel/Pretty.hs
+++ b/quickcheck-threatmodel/src/Test/QuickCheck/ThreatModel/Pretty.hs
@@ -1,9 +1,9 @@
 
 module Test.QuickCheck.ThreatModel.Pretty where
 
-import Cardano.Api
-import Cardano.Api.Byron
-import Cardano.Api.Shelley
+import Cardano.Api hiding (Doc, (<+>))
+import Cardano.Api.Byron hiding (Doc, (<+>))
+import Cardano.Api.Shelley hiding (Doc, (<+>))
 import Cardano.Ledger.Alonzo.Tx qualified as Ledger (Data)
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
 import Cardano.Ledger.SafeHash qualified as Ledger
@@ -153,13 +153,13 @@ prettyTx tx@(Tx body@(TxBody (TxBodyContent{..})) _) =
               TxBodyScriptData _ _ (Ledger.Redeemers rdmrs) -> rdmrs
               TxBodyNoScriptData                            -> mempty
 
-prettyRedeemer :: [TxIn] -> [PolicyId] -> Ledger.PlutusPurpose Ledger.AsIndex LedgerEra -> (Ledger.Data LedgerEra, Ledger.ExUnits) -> Doc
+prettyRedeemer :: [TxIn] -> [PolicyId] -> Ledger.PlutusPurpose Ledger.AsIx LedgerEra -> (Ledger.Data LedgerEra, Ledger.ExUnits) -> Doc
 prettyRedeemer inps mints purpose (dat, _) = pTag <:> prettyScriptData (getScriptData $ fromAlonzoData dat)
   where
     pTag =
       case purpose of
-        Ledger.AlonzoSpending (Ledger.AsIndex ix) -> "Spend" <+> prettyIn (inps !! fromIntegral ix)
-        Ledger.AlonzoMinting (Ledger.AsIndex ix)  -> "Mint" <+> prettyHash (mints !! fromIntegral ix)
+        Ledger.AlonzoSpending (Ledger.AsIx ix) -> "Spend" <+> prettyIn (inps !! fromIntegral ix)
+        Ledger.AlonzoMinting (Ledger.AsIx ix)  -> "Mint" <+> prettyHash (mints !! fromIntegral ix)
         Ledger.AlonzoCertifying _                 -> "Certify"
         Ledger.AlonzoRewarding _                  -> "Reward"
 

--- a/quickcheck-threatmodel/src/Test/QuickCheck/ThreatModel/TxModifier.hs
+++ b/quickcheck-threatmodel/src/Test/QuickCheck/ThreatModel/TxModifier.hs
@@ -204,7 +204,7 @@ applyTxMod tx utxos (RemoveInput i) =
                 }
     scriptData' = case Ledger.indexOf (Ledger.AsItem (toShelleyTxIn i)) btbInputs of
       SNothing  -> scriptData
-      SJust (Ledger.AsIndex idx) -> recomputeScriptData (Just idx) idxUpdate scriptData
+      SJust (Ledger.AsIx idx) -> recomputeScriptData (Just idx) idxUpdate scriptData
         where
           idxUpdate idx'
             | idx' > idx = idx' - 1
@@ -241,7 +241,7 @@ applyTxMod tx utxos (AddInput addr value datum rscript False) =
 
     input   = toShelleyTxIn txIn
     inputs' = Set.insert input btbInputs
-    SJust (Ledger.AsIndex idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
+    SJust (Ledger.AsIx idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
 
     txOut   = makeTxOut addr value datum rscript
     utxos'  = UTxO . Map.insert txIn txOut . unUTxO $ utxos
@@ -306,7 +306,7 @@ applyTxMod tx utxos (AddReferenceScriptInput script value datum redeemer) =
     txOut  = makeTxOut addr value datum ReferenceScriptNone
     utxos' = UTxO . Map.insert txIn txOut . unUTxO $ utxos
 
-    SJust (Ledger.AsIndex idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
+    SJust (Ledger.AsIx idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
     idxUpdate idx'
       | idx' >= idx = idx' + 1
       | otherwise   = idx'
@@ -340,7 +340,7 @@ applyTxMod tx utxos (AddPlutusScriptInput script value datum redeemer rscript) =
     newScript = toShelleyScript @Era scriptInEra
     scripts'  = scripts ++ [newScript]
 
-    SJust (Ledger.AsIndex idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
+    SJust (Ledger.AsIx idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
     idxUpdate idx'
       | idx' >= idx = idx' + 1
       | otherwise   = idx'
@@ -376,7 +376,7 @@ applyTxMod tx utxos (AddSimpleScriptInput script value rscript False) =
     newScript = toShelleyScript @Era scriptInEra
     scripts'  = scripts ++ [newScript]
 
-    SJust (Ledger.AsIndex idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
+    SJust (Ledger.AsIx idx) = Ledger.indexOf (Ledger.AsItem input) inputs'
     idxUpdate idx'
       | idx' >= idx = idx' + 1
       | otherwise   = idx'
@@ -465,7 +465,7 @@ applyTxMod tx utxos (ChangeScriptInput txIn mvalue mdatum mredeemer mrscript) =
       TxBodyNoScriptData -> error "No script data available"
       TxBodyScriptData _ (Ledger.TxDats dats) (Ledger.Redeemers rdmrs) ->
         (fromJust $ Map.lookup utxoDatumHash dats,
-         fromJust $ Map.lookup (Ledger.AlonzoSpending (Ledger.AsIndex idx)) rdmrs)
+         fromJust $ Map.lookup (Ledger.AlonzoSpending (Ledger.AsIx idx)) rdmrs)
 
     utxoDatumHash = case utxoDatum of
       TxOutDatumNone       -> error "No existing datum"
@@ -487,7 +487,7 @@ applyTxMod tx utxos (ChangeScriptInput txIn mvalue mdatum mredeemer mrscript) =
     utxos' = UTxO . Map.insert txIn txOut . unUTxO $ utxos
 
     idx = case Ledger.indexOf (Ledger.AsItem (toShelleyTxIn txIn)) btbInputs of
-      SJust (Ledger.AsIndex idx) -> idx
+      SJust (Ledger.AsIx idx) -> idx
       _                          -> error "The impossible happened!"
 
     scriptData' = addScriptData idx adatum


### PR DESCRIPTION
Working with the CI team I suggested to drop 8.10 and 9.2 in this branch. Would there be any objections to that? We can support 9.10 shortly.